### PR TITLE
Catch the asyncio timout exception too

### DIFF
--- a/pysaj/__init__.py
+++ b/pysaj/__init__.py
@@ -223,7 +223,7 @@ class SAJ(object):
                                       sen.name, sen.value)
 
                     return True
-        except (aiohttp.client_exceptions.ClientConnectorError,
+        except (aiohttp.client_exceptions.ClientConnectorError, asyncio.exceptions.TimeoutError,
                 concurrent.futures._base.TimeoutError):
             # Connection to inverter not possible.
             # This can be "normal" - so warning instead of error - as SAJ


### PR DESCRIPTION
In my HomeAssistant this timout exception is thrown if the device is not available (e.g. during the night) and it will not reconnect otherwise.